### PR TITLE
Enable FORCE_SSL_ADMIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ no specific requirements
 | `wordpress_password`      | 'wordpress' | The password of the database user.                |
 | `wordpress_plugins`       | []          | Plugins to be installed. See below. (since 1.1.0) |
 | `wordpress_themes`        | []          | Themes to be installed. See below. (since 1.1.0)  |
+| `wordpress_force_ssl`     | false       | Forces HTTPS on admin pages.                      |
 
 **Remark:** it is **very strongly** suggested to change the default password.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,5 @@ wordpress_password: wordpress
 
 wordpress_plugins: []
 wordpress_themes: []
+
+wordpress_force_ssl: false

--- a/templates/wp-config.php.j2
+++ b/templates/wp-config.php.j2
@@ -33,6 +33,21 @@ define('DB_CHARSET', 'utf8');
 /** The Database Collate type. Don't change this if in doubt. */
 define('DB_COLLATE', '');
 
+{% if wordpress_force_ssl %}
+
+/** 
+ * Force SSL on Admin pages
+ */
+
+define('FORCE_SSL_ADMIN', true);
+define('FORCE_SSL_LOGIN', true);
+
+/** Fix for redirect loop occuring if WordPress is behind a loadbalancer or cache. */
+if ($_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')
+  $_SERVER['HTTPS'] = 'on';
+
+{% endif %}
+
 /**#@+
  * Authentication Unique Keys and Salts.
  *


### PR DESCRIPTION
Added a variable `wordpress_force_ssl` (defaults to `false`) that, when enabled, defines `FORCE_SSL_ADMIN` and `FORCE_SSL_LOGIN` in `wp-config.php` in order to force https on admin pages. 

Also includes a solution to the redirect loop caused when using https and wordpress is behind an SSL terminating load balancer or cache. 

Source: <https://trick77.com/prevent-ssl-redirect-loop-using-wordpress-and-haproxy/>