### PR TITLE
only set selinux when selinux is available

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -50,3 +50,5 @@
     target: "{{ wordpress_directory }}"
     setype: httpd_sys_rw_content_t
     state: present
+  when: ansible_selinux.status == 'enabled' 
+


### PR DESCRIPTION
fixes:
TASK [bertvv.wordpress : Setting SELinux context] *****************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ModuleNotFoundError: No module named 'selinux'
fatal: [blog]: FAILED! => {"changed": false, "msg": "Failed to import the required Python library (libselinux-python) on blog's Python /usr/libexec/platform-python. Please read module documentation and install in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"}