### PR TITLE
add support for https behind proxy

### DIFF
--- a/templates/wp-config.php.j2
+++ b/templates/wp-config.php.j2
@@ -99,4 +99,10 @@ if ( !defined('ABSPATH') )
 /** Sets up WordPress vars and included files. */
 require_once(ABSPATH . 'wp-settings.php');
 
+/** Let wordpress be installed behind a revers proxy doing ssl **/
+if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+        $_SERVER['HTTPS'] = 'on';
+}
+
+
 // vim: ft=php


### PR DESCRIPTION
the proxy shoudl set the `X-Forwarded-Proto` header to 'https' to enable https in wordpress admin interface