### PR TITLE
Rewrite wp-version to download as default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ You need to have a database server set up with a database, user, and password th
 | :---                          | :---        | :---                                                                                               |
 | `wordpress_allow_file_mods`   | false       | When `true`, installation of additional themes and plugins through the admin dashboard is allowed |
 | `wordpress_automatic_updates` | false       | When `true`, automatic updates are enabled                                                         |
+| `wordpress_version`           | '5.0.8'     | The wordpress version to download.                                                                               |
 | `wordpress_database_host`     | 'localhost' | The database server.                                                                               |
 | `wordpress_database`          | 'wordpress' | The name of the database for Wordpress.                                                            |
 | `wordpress_debug`             | false       | When `true`, enables debug mode                                                                    |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 # roles/wordpress/defaults/main.yml
 ---
 
+wordpress_version: 5.0.8
 wordpress_database_host: localhost
 wordpress_database: wordpress
 wordpress_user: wordpress

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -22,18 +22,18 @@
 
 - name: Download Wordpress
   get_url:
-    url: https://wordpress.org/wordpress-5.0.8.tar.gz
+    url: https://wordpress.org/wordpress-{{ wordpress_version }}.tar.gz
     dest: "{{ wordpress_install_directory }}"
 
 - name: Unzipping wordpress
   unarchive:
-    src: "{{ wordpress_install_directory }}/wordpress-5.0.8.tar.gz"
+    src: "{{ wordpress_install_directory }}/wordpress-{{ wordpress_version }}.tar.gz"
     dest: "{{ wordpress_install_directory }}"
     remote_src: true
 
 - name: Remove wordpress.tar.gz file
   file:
-    path: "{{ wordpress_install_directory }}/wordpress-5.0.8.tar.gz"
+    path: "{{ wordpress_install_directory }}/wordpress-{{ wordpress_version }}.tar.gz"
     state: absent
 
 - name: Setting ownership


### PR DESCRIPTION
Could we provide a variable within defaults/main.yml for wp-version to download instead of hardcoded version in tasks/install.xml?